### PR TITLE
Fix inconsistent frame time in animation

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -24,7 +24,7 @@ allowed_origins = [
     origin.strip() 
     for origin in os.getenv(
         "ALLOWED_ORIGINS",
-        "http://localhost:5173,http://127.0.0.1:5173"  # Default for local development
+        "http://localhost:5173,http://127.0.0.1:5173,http://localhost:5174,http://127.0.0.1:5174"  # Default for local development
     ).split(",")
     if origin.strip()  # Filter out empty strings
 ]

--- a/frontend/src/components/AstronomyScene.vue
+++ b/frontend/src/components/AstronomyScene.vue
@@ -245,12 +245,27 @@ function calculateFrameInterval() {
   const firstFrame = new Date(data.value.frames[0].datetime);
   const secondFrame = new Date(data.value.frames[1].datetime);
   
+  // Validate that the dates are valid
+  if (!isFinite(firstFrame.getTime()) || !isFinite(secondFrame.getTime())) {
+    frameIntervalMs.value = 1000; // Fall back to default if dates are invalid
+    return;
+  }
+  
   // Calculate the time difference in milliseconds
   const realTimeDiffMs = secondFrame.getTime() - firstFrame.getTime();
   
+  // Validate that the time difference is positive
+  if (realTimeDiffMs <= 0) {
+    console.warn('Frame timestamps are not in chronological order or are identical. Using default interval.');
+    frameIntervalMs.value = 1000; // Fall back to default if frames are out of order
+    return;
+  }
+  
   // Scale to a reasonable animation speed (e.g., 1 real hour = 1 second of animation)
   // This gives us a base speed that makes sense for visualization
-  const scaleFactor = 1000 / 3600000; // 1 second per hour
+  const MILLISECONDS_PER_SECOND = 1000;
+  const MILLISECONDS_PER_HOUR = 60 * 60 * 1000;
+  const scaleFactor = MILLISECONDS_PER_SECOND / MILLISECONDS_PER_HOUR;
   frameIntervalMs.value = realTimeDiffMs * scaleFactor;
   
   // Ensure a minimum interval to prevent too-fast animations


### PR DESCRIPTION
Fixes #11

The animation was advancing frames at a fixed rate (100ms per frame) regardless of the actual time intervals between frames in the data. This caused animations to play at inconsistent speeds - e.g., frames representing 1-hour intervals played at the same rate as frames representing 1-day intervals.

Changes:
- Added frameIntervalMs ref to track calculated interval between frames
- Added calculateFrameInterval() function that:
  - Parses datetime values from first two frames
  - Calculates actual time difference
  - Scales to reasonable visualization speed (1 hour = 1 second)
  - Sets minimum 50ms interval to prevent too-fast animations
- Updated updateAnimation() to use calculated interval
- Animation speed slider now correctly scales the time-based interval
- Allow port 5174 for local development

Now animations respect the actual temporal spacing of the data, providing consistent visual playback speed regardless of the time range or frame count.